### PR TITLE
add ability to add a list of useremails for admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ MIT Licensed. See [LICENSE](https://github.com/deliveryhero/tf-ssh-bastion/tree/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_explicit_sso_admin_users"></a> [allow\_explicit\_sso\_admin\_users](#input\_allow\_explicit\_sso\_admin\_users) | Enable a trust relationship of the sso admin Role for certain user emails provided with allowed\_sso\_assume\_policy\_users | `boolean` | `false` | no |
+| <a name="input_allowed_sso_admin_assume_policy_user_emails"></a> [allowed\_sso\_admin\_assume\_policy\_user\_emails](#input\_allowed\_sso\_admin\_assume\_policy\_user\_emails) | List of User Emails to explicitly allow using a sso admin role | `list(string)` | `[]` | no |
 | <a name="input_extra_policies_administrator"></a> [extra\_policies\_administrator](#input\_extra\_policies\_administrator) | Any extra policy ARNs to attach to the administrator role | `list(any)` | `[]` | no |
 | <a name="input_extra_policies_developer"></a> [extra\_policies\_developer](#input\_extra\_policies\_developer) | Any extra policy ARNs to attach to the developer role | `list(any)` | `[]` | no |
 | <a name="input_extra_policies_ec2fullaccess"></a> [extra\_policies\_ec2fullaccess](#input\_extra\_policies\_ec2fullaccess) | Any extra policy ARNs to attach to the EC2 full access role | `list(any)` | `[]` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,26 @@
+data "aws_iam_policy_document" "sso_assume_role_policy_allow_explicit_users" {
+  statement {
+    actions = ["sts:AssumeRoleWithSAML"]
+
+    principals {
+      type        = "Federated"
+      identifiers = compact(concat([aws_iam_saml_provider.main.arn], var.iam_assume_role_extra_identifiers))
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "SAML:aud"
+      values   = ["https://signin.aws.amazon.com/saml"]
+    }
+
+    condition {
+      test     = "StringLikeIfExists"
+      variable = "sts:RoleSessionName"
+      values   = var.allowed_sso_admin_assume_policy_user_emails
+    }
+  }
+}
+
 data "aws_iam_policy_document" "sso_assume_role_policy" {
   statement {
     actions = ["sts:AssumeRoleWithSAML"]
@@ -19,7 +42,7 @@ data "aws_iam_policy_document" "sso_assume_role_policy" {
 resource "aws_iam_role" "administrator" {
   name                 = "${var.iam_role_prefix}administrator"
   path                 = var.iam_role_path
-  assume_role_policy   = data.aws_iam_policy_document.sso_assume_role_policy.json
+  assume_role_policy   = var.allow_explicit_sso_admin_users ? data.aws_iam_policy_document.sso_assume_role_policy_allow_explicit_users : data.aws_iam_policy_document.sso_assume_role_policy.json
   max_session_duration = var.role_max_session_duration
   tags                 = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,18 @@ variable "extra_policies_poweruser" {
   default     = []
 }
 
+variable "allow_explicit_sso_admin_users" {
+  type        = boolean
+  description = "Enable a trust relationship of the sso admin Role for certain user emails provided with allowed_sso_assume_policy_users"
+  default     = false
+}
+
+variable "allowed_sso_admin_assume_policy_user_emails" {
+  type        = list(string)
+  description = "List of User Emails to explicitly allow using a sso admin role"
+  default     = []
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources."
   type        = map(string)


### PR DESCRIPTION
We add an ability to add a list of user_emails to explicitly allow using the sso-administrator role